### PR TITLE
Fix runtime issues for Django 5.2 / Python 3.10

### DIFF
--- a/chcemvediet/apps/anonymization/context_processors.py
+++ b/chcemvediet/apps/anonymization/context_processors.py
@@ -1,6 +1,6 @@
 # vim: expandtab
 # -*- coding: utf-8 -*-
-from anonymization import ANONYMIZATION_STRING
+from .anonymization import ANONYMIZATION_STRING
 
 
 def constants(request):

--- a/chcemvediet/sass_functions.py
+++ b/chcemvediet/sass_functions.py
@@ -7,10 +7,10 @@ def static(path):
     # expects reference to the real function, but ``django_libsass`` module may not be imported in
     # ``settings.py``, because it requires settings already configured.
     from django.templatetags.static import static as django_static
-    return '"{}"'.format(django_static(path))
+    return django_static(path)
 
 def md5(path):
     import hashlib
     from django.contrib.staticfiles.finders import find
-    with open(find(path)) as f:
+    with open(find(path), 'rb') as f:
         return hashlib.md5(f.read()).hexdigest()

--- a/chcemvediet/templates/main/homepage/blogs/sk/dostupnost_pre_kazdeho.html
+++ b/chcemvediet/templates/main/homepage/blogs/sk/dostupnost_pre_kazdeho.html
@@ -1,6 +1,6 @@
 {# vim: set filetype=htmldjango shiftwidth=2 :#}
 {% extends base_template|default:"main/homepage/blogs/base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% comment %}
  %

--- a/chcemvediet/templates/main/homepage/blogs/sk/rozdiely_vo_vybavovani.html
+++ b/chcemvediet/templates/main/homepage/blogs/sk/rozdiely_vo_vybavovani.html
@@ -1,6 +1,6 @@
 {# vim: set filetype=htmldjango shiftwidth=2 :#}
 {% extends base_template|default:"main/homepage/blogs/base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% comment %}
  %

--- a/chcemvediet/templates/main/homepage/casestudy/sk/ako_infoziadosti_pomahaju.html
+++ b/chcemvediet/templates/main/homepage/casestudy/sk/ako_infoziadosti_pomahaju.html
@@ -1,6 +1,6 @@
 {# vim: set filetype=htmldjango shiftwidth=2 :#}
 {% extends "main/homepage/casestudy/base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% comment %}
  %

--- a/chcemvediet/templates/main/homepage/casestudy/sk/ako_pomaha_nas_portal.html
+++ b/chcemvediet/templates/main/homepage/casestudy/sk/ako_pomaha_nas_portal.html
@@ -1,6 +1,6 @@
 {# vim: set filetype=htmldjango shiftwidth=2 :#}
 {% extends "main/homepage/casestudy/base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% comment %}
  %

--- a/chcemvediet/templates/main/homepage/casestudy/sk/sef_danovych_kriminalistov.html
+++ b/chcemvediet/templates/main/homepage/casestudy/sk/sef_danovych_kriminalistov.html
@@ -1,6 +1,6 @@
 {# vim: set filetype=htmldjango shiftwidth=2 :#}
 {% extends "main/homepage/casestudy/base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% comment %}
  %

--- a/chcemvediet/templates/main/homepage/steps.html
+++ b/chcemvediet/templates/main/homepage/steps.html
@@ -1,6 +1,6 @@
 {# vim: set filetype=htmldjango shiftwidth=2 :#}
 {% load trans from i18n %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% comment %}
  %

--- a/chcemvediet/templates/main/snippets/footer/partners.html
+++ b/chcemvediet/templates/main/snippets/footer/partners.html
@@ -1,5 +1,5 @@
 {# vim: set filetype=htmldjango shiftwidth=2 :#}
-{% load static from staticfiles %}
+{% load static %}
 
 {% comment %}
  %

--- a/chcemvediet/templates/main/snippets/header/language.html
+++ b/chcemvediet/templates/main/snippets/header/language.html
@@ -1,5 +1,5 @@
 {# vim: set filetype=htmldjango shiftwidth=2 :#}
-{% load static from staticfiles %}
+{% load static %}
 {% load change_lang from poleno.utils %}
 
 {% comment %}

--- a/chcemvediet/templates/styleguide/components/blog.html
+++ b/chcemvediet/templates/styleguide/components/blog.html
@@ -1,6 +1,6 @@
 {# vim: set filetype=htmldjango shiftwidth=2 :#}
 {% extends "main/homepage/blogs/base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% load lorem from poleno.utils %}
 
 {% comment %}

--- a/chcemvediet/templates/styleguide/components/casestudy.html
+++ b/chcemvediet/templates/styleguide/components/casestudy.html
@@ -1,6 +1,6 @@
 {# vim: set filetype=htmldjango shiftwidth=2 :#}
 {% extends "main/homepage/casestudy/base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% load lorem from poleno.utils %}
 
 {% comment %}

--- a/manage.py
+++ b/manage.py
@@ -3,6 +3,10 @@ import os
 import sys
 
 if __name__ == "__main__":
+    # Add vendor/ to sys.path so vendored packages shadow pip-installed ones
+    vendor_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'vendor')
+    if vendor_path not in sys.path:
+        sys.path.insert(0, vendor_path)
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "chcemvediet.settings")
 
     from django.core.management import execute_from_command_line

--- a/media/pages/sk/projekt-podporili/page.html
+++ b/media/pages/sk/projekt-podporili/page.html
@@ -1,5 +1,5 @@
 {# vim: set filetype=htmldjango shiftwidth=2 :#}
-{% load static from staticfiles %}
+{% load static %}
 
 
 <h1>Projekt podporili</h1>

--- a/poleno/pages/templates/pages/alternatives.html
+++ b/poleno/pages/templates/pages/alternatives.html
@@ -1,6 +1,6 @@
 {# vim: set filetype=htmldjango shiftwidth=2 :#}
 {% extends "main/base/single_column.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% load trans from i18n %}
 
 {% comment %}

--- a/poleno/timewarp/timewarp.py
+++ b/poleno/timewarp/timewarp.py
@@ -3,7 +3,7 @@
 import sys
 import time as time_orig
 import datetime as datetime_orig
-import copy_reg
+import copyreg
 
 from django.core.cache import cache
 
@@ -63,8 +63,7 @@ class _WarpedTime(object):
 
 class _WarpedDatetime(object):
 
-    class date(datetime_orig.date):
-        __metaclass__ = _meta_factory(datetime_orig.date)
+    class date(datetime_orig.date, metaclass=_meta_factory(datetime_orig.date)):
 
         def __new__(cls, *args, **kwargs):
             return datetime_orig.date(*args, **kwargs)
@@ -73,8 +72,7 @@ class _WarpedDatetime(object):
         def today(cls):
             return datetime_orig.datetime.fromtimestamp(timewarp.warped_time).date()
 
-    class datetime(datetime_orig.datetime):
-        __metaclass__ = _meta_factory(datetime_orig.datetime)
+    class datetime(datetime_orig.datetime, metaclass=_meta_factory(datetime_orig.datetime)):
 
         def __new__(cls, *args, **kwargs):
             return datetime_orig.datetime(*args, **kwargs)
@@ -124,17 +122,17 @@ class Timewarp(object):
         if not self._enabled:
             self._enabled = True
             self._remap_modules({a: b for a, b in self._remap})
-            copy_reg.pickle(datetime_orig.date,
+            copyreg.pickle(datetime_orig.date,
                     lambda d: (_WarpedDatetime.date,) + d.__reduce__()[1:])
-            copy_reg.pickle(datetime_orig.datetime,
+            copyreg.pickle(datetime_orig.datetime,
                     lambda d: (_WarpedDatetime.datetime,) + d.__reduce__()[1:])
 
     def disable(self):
         if self._enabled:
             self._enabled = False
             self._remap_modules({b: a for a, b in self._remap})
-            copy_reg.pickle(datetime_orig.date, lambda d: d.__reduce__())
-            copy_reg.pickle(datetime_orig.datetime, lambda d: d.__reduce__())
+            copyreg.pickle(datetime_orig.date, lambda d: d.__reduce__())
+            copyreg.pickle(datetime_orig.datetime, lambda d: d.__reduce__())
 
     def _remap_modules(self, remap):
         types = [type(a) for a in remap]

--- a/poleno/utils/template.py
+++ b/poleno/utils/template.py
@@ -19,11 +19,8 @@ from .misc import squeeze
 
 
 def render_to_string(template_name, dictionary=None, context_instance=None, dirs=None):
-    if context_instance is None:
-        request = get_request()
-        if request is not None:
-            context_instance = RequestContext(request)
-    return django_render_to_string(template_name, dictionary, context_instance, dirs)
+    request = get_request()
+    return django_render_to_string(template_name, dictionary, request=request)
 
 @lazy_decorator(str)
 def lazy_render_to_string(*args, **kwargs):
@@ -74,14 +71,26 @@ class TranslationLoader(BaseLoader):
             self._cached_loader = self.engine.find_template_loader(self._loader)
         return self._cached_loader
 
-    def load_template(self, template_name, template_dirs=None):
+    def get_template_sources(self, template_name):
         language = get_language()
         template_base, template_ext = splitext(template_name)
+        translated_name = '{}.{}{}'.format(template_base, language, template_ext)
+        for source in self.loader.get_template_sources(translated_name):
+            yield source
+        for source in self.loader.get_template_sources(template_name):
+            yield source
+
+    def get_contents(self, origin):
+        return self.loader.get_contents(origin)
+
+    def get_template(self, template_name, skip=None):
+        language = get_language()
+        template_base, template_ext = splitext(template_name)
+        translated_name = '{}.{}{}'.format(template_base, language, template_ext)
         try:
-            return self.loader.load_template(u'{}.{}{}'.format(
-                template_base, language, template_ext), template_dirs)
+            return self.loader.get_template(translated_name, skip)
         except TemplateDoesNotExist:
-            return self.loader.load_template(template_name, template_dirs)
+            return self.loader.get_template(template_name, skip)
 
 
 class AppLoader(BaseLoader):
@@ -113,23 +122,26 @@ class AppLoader(BaseLoader):
     Which is based on: http://djangosnippets.org/snippets/1376/
     """
 
-    def load_template_source(self, template_name, template_dirs=None):
-        u"""
-        Loads the template from the app specified by a colon-prefixed name. If the name does not
-        contain an app name (no colon), raises TemplateDoesNotExist.
-        """
-        if u':' not in template_name:
-            raise TemplateDoesNotExist(template_name)
-        app_name, tmpl_name = template_name.split(u':', 1)
+    def get_template_sources(self, template_name):
+        from django.template import Origin
+        if ':' not in template_name:
+            return
+        app_name, tmpl_name = template_name.split(':', 1)
         for app in apps.get_app_configs():
             if app.label == app_name:
-                template_path = join(app.path, u'templates', tmpl_name)
-                try:
-                    with io.open(template_path, encoding=self.engine.file_charset) as fp:
-                        return fp.read(), template_path
-                except IOError:
-                    raise TemplateDoesNotExist(template_name)
-        raise TemplateDoesNotExist(template_name)
+                template_path = join(app.path, 'templates', tmpl_name)
+                yield Origin(
+                    name=template_path,
+                    template_name=template_name,
+                    loader=self,
+                )
+
+    def get_contents(self, origin):
+        try:
+            with io.open(origin.name, encoding=self.engine.file_charset) as fp:
+                return fp.read()
+        except IOError:
+            raise TemplateDoesNotExist(origin)
 
 
 class Library(template.Library):

--- a/poleno/utils/templatetags/poleno/utils.py
+++ b/poleno/utils/templatetags/poleno/utils.py
@@ -401,4 +401,4 @@ def assets(types, external=False, local=False):
             if type_re.search(url):
                 res.append(format_html(type_tpl, url=url))
                 break
-    return u'\n'.join(res)
+    return mark_safe(u'\n'.join(res))


### PR DESCRIPTION
## Summary
- Fix Python 2→3 leftovers missed in the upgrade: `copy_reg`→`copyreg`, `__metaclass__` syntax, binary file mode for `hashlib`, relative imports
- Update custom template loaders (`TranslationLoader`, `AppLoader`) to Django 5.2 API (`get_template_sources`/`get_contents` instead of removed `load_template`/`load_template_source`)
- Fix `assets` template tag to return `mark_safe` output (HTML was being auto-escaped in Django 5.2)
- Fix `sass_functions.static()` double-quoting URLs which broke fontello icon font loading
- Replace deprecated `{% load static from staticfiles %}` with `{% load static %}` in all templates
- Add `vendor/` to `sys.path` in `manage.py` so vendored `django_cron` package shadows the pip-installed one (which uses removed `index_together`)

## Test plan
- [x] All 7 key pages render with HTTP 200
- [x] Text content comparison: 6/7 pages identical, 1 page has minor cosmetic link rendering difference
- [x] Fontello icons display correctly
- [x] CSS compilation (libsass) works
- [x] Database migrations apply successfully
- Old site: https://test.chcemvediet.sk:8443/sk/ 
- New site: https://test.chcemvediet.sk:8444/sk/

🤖 Generated with [Claude Code](https://claude.com/claude-code)